### PR TITLE
Add support for setPassportDataErrors method and corresponding types

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -363,7 +363,7 @@ Latest version : 🚀 December 4, 2024 ([Bot API 8.1](https://core.telegram.org/
   - [x] PassportFile [🔗](https://core.telegram.org/bots/api#passportfile)
   - [x] EncryptedPassportElement [🔗](https://core.telegram.org/bots/api#encryptedpassportelement)
   - [x] EncryptedCredentials [🔗](https://core.telegram.org/bots/api#encryptedcredentials)
-  - [ ] setPassportDataErrors [🔗](https://core.telegram.org/bots/api#setpassportdataerrors)
+  - [x] setPassportDataErrors [🔗](https://core.telegram.org/bots/api#setpassportdataerrors)
   - [x] PassportElementError [🔗](https://core.telegram.org/bots/api#passportelementerror)
   - [x] PassportElementErrorDataField [🔗](https://core.telegram.org/bots/api#passportelementerrordatafield)
   - [x] PassportElementErrorFrontSide [🔗](https://core.telegram.org/bots/api#passportelementerrorfrontside)

--- a/src/entity/Passport/@types/SetPassportDataErrorsParams.ts
+++ b/src/entity/Passport/@types/SetPassportDataErrorsParams.ts
@@ -1,0 +1,16 @@
+import { PassportElementError } from '@entity/@types/PassportElementError'
+
+/**
+ * Represents the parameters required to set passport data errors for a user.
+ */
+export interface SetPassportDataErrorsParams {
+  /**
+   * Required. User identifier.
+   */
+  user_id: number
+
+  /**
+   * Required. A JSON-serialized array of PassportElementError objects describing the errors.
+   */
+  errors: PassportElementError[]
+}

--- a/src/entity/Passport/Passport.ts
+++ b/src/entity/Passport/Passport.ts
@@ -1,3 +1,12 @@
 import BaseTelegramApiEntity from '@core/BaseTelegramApiEntity'
+import { SetPassportDataErrorsParams } from './@types/SetPassportDataErrorsParams'
 
-export default class Passport extends BaseTelegramApiEntity {}
+export default class Passport extends BaseTelegramApiEntity {
+  /**
+   * Use this method to inform a user that some of the Telegram Passport elements they provided contain errors.
+   * On success, returns true.
+   */
+  async setPassportDataErrors(setPassportDataErrorsParams: SetPassportDataErrorsParams) {
+    return this.jsonCall<boolean>('setPassportDataErrors', setPassportDataErrorsParams)
+  }
+}

--- a/test/passport.test.ts
+++ b/test/passport.test.ts
@@ -1,0 +1,35 @@
+import Telegram from '@src/Telegram'
+
+describe('🎮 Telegram Passport Entity', () => {
+  const apiKey = String(process.env.API_KEY)
+  const userId = Number(process.env.USER_ID)
+  const sampleFileHash = String(process.env.FILE_HASH)
+  const telegramClient = new Telegram({ apiKey })
+
+  it('Validates required environment variables.', () => {
+    expect(apiKey).toBeDefined()
+    expect(apiKey).not.toBe('')
+    expect(sampleFileHash).not.toBe('')
+    expect(userId).toBeDefined()
+    expect(Number.isNaN(userId)).toBe(false)
+  })
+
+  it('Correctly initializes with a valid API key.', () => {
+    expect(telegramClient).toBeDefined()
+  })
+
+  it('Correctly throw error to user.', async () => {
+    const result = await telegramClient.setPassportDataErrors({
+      user_id: userId,
+      errors: [
+        {
+          source: 'file',
+          type: 'bank_statement',
+          file_hash: sampleFileHash,
+          message: 'Invalid bank statement photo.',
+        },
+      ],
+    })
+    expect(result).toBe(true)
+  })
+})


### PR DESCRIPTION
# Add support for `setPassportDataErrors` method and corresponding types

This pull request introduces support for the `setPassportDataErrors` method in the `Passport` entity, allowing users to set passport data errors for Telegram Passport elements. The following changes have been made:

## Changes

- **`SetPassportDataErrorsParams` Type:**  
  A new type definition has been added to ensure the correct structure for the parameters passed to the `setPassportDataErrors` method. The `SetPassportDataErrorsParams` interface includes:
  - `user_id`: The identifier of the user.
  - `errors`: An array of `PassportElementError` objects describing the errors in the passport data.

- **`Passport` Class:**  
  The `Passport` class has been updated to include the `setPassportDataErrors` method. This method:
  - Accepts an instance of `SetPassportDataErrorsParams`.
  - Performs the operation to inform users about the errors in their provided passport data.

- **Test Case:**  
  A new test file (`passport.test.ts`) has been added to validate the functionality of the `setPassportDataErrors` method. The tests include:
  - Validation of required environment variables.
  - Correct initialization of the `Telegram` client with a valid API key.
  - Verification that the `setPassportDataErrors` method works correctly by throwing the expected errors.

## Details

The `setPassportDataErrors` method helps developers inform users about errors in the Telegram Passport data elements they have provided. It is particularly useful when a user's passport data needs corrections before it can be processed further.
